### PR TITLE
38 clean up metastore variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ It currently supports exporting these formats:
 
 The `Pipeline` is the primary way to link `Pipes` together to create a unified data pipeline.
 
-It takes in a list of raw, conformed, canonical, and export `Pipes` and executes them sequentially.
+It takes in a list of raw, conformed, standard, canonical, and export `Pipes` and executes them sequentially.
 
 There are two kinds of pipelines you can build:
 

--- a/polta/metastore.py
+++ b/polta/metastore.py
@@ -15,6 +15,18 @@ from polta.schemas.system import file_history, pipe_history
 @dataclass
 class Metastore:
   """Dataclass for managing Polta metastores
+
+  The key concepts are below:
+    1. Domain: the high-level category of data
+    2. Quality: the various table qualities under a given domain
+  
+  There are two main directories in a metastore:
+    1. Tables: all of the table datasets for a metastore
+    2. Volumes: file storage containing system tables, ingestion zones, export files, etc.
+  
+  Below are the available system tables:
+    1. file_history: stores metadata about every file that has been ingested
+    2. pipe_history: stores metadata about every pipe execution
   
   Optional Args:
     main_path (str): the directory of the metastore (default CWD + 'metastore')

--- a/polta/metastore.py
+++ b/polta/metastore.py
@@ -20,17 +20,22 @@ class Metastore:
     main_path (str): the directory of the metastore (default CWD + 'metastore')
 
   Initialized Fields:
+    name (str): the name of the metastore (i.e., the basename of main_path)
     tables_directory (str): the path to the tables
     volumes_directory (str): the path to the volumes
+    file_history_path (str): the absolute path to the file_history table
+    pipe_history_path (str): the absolute path to the pipe_history table
   """
   main_path: str = field(default_factory=lambda: path.join(getcwd(), 'metastore'))
 
+  name: str = field(init=False)
   tables_directory: str = field(init=False)
   volumes_directory: str = field(init=False)
   file_history_path: str = field(init=False)
   pipe_history_path: str = field(init=False)
 
   def __post_init__(self) -> None:
+    self.name: str = path.basename(self.main_path)
     self.tables_directory: str = path.join(self.main_path, 'tables')
     self.volumes_directory: str = path.join(self.main_path, 'volumes')
     self.exports_directory: str = path.join(self.volumes_directory, 'exports')

--- a/tests/test_metastore.py
+++ b/tests/test_metastore.py
@@ -27,6 +27,9 @@ class TestMetastore(TestCase):
     assert path.exists(self.pm.tables_directory)
     assert path.exists(self.pm.volumes_directory)
 
+    # Assert proper metastore metadata
+    assert self.pm.name == self.td.metastore_name
+
     # Destory secondary metastore
     rmtree(self.pm_init.main_path)
     assert not path.exists(self.pm_init.main_path)

--- a/tests/testing_data/metastore.py
+++ b/tests/testing_data/metastore.py
@@ -8,6 +8,7 @@ from sample.metastore import metastore_init
 
 class TestingData:
   """Contains test data for the metastore"""
+  metastore_name: str = 'test_metastore'
   domains: list[str] = ['in_memory', 'standard']
   qualities: list[TableQuality] = [
     TableQuality.CANONICAL,


### PR DESCRIPTION
This branch:
1. Adds `Metastore.name`.
2. Cleans up the README.md file, since we now have a `standard` table quality.
3. Fleshes out the `Metastore` docstring for clarity.
4. Writes missing `file_history_path` and `pipe_history_path` documentation in the docstring.